### PR TITLE
Update to SpringRoll 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1532,9 +1532,9 @@
       "dev": true
     },
     "bellhop-iframe": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bellhop-iframe/-/bellhop-iframe-2.1.2.tgz",
-      "integrity": "sha512-mraO53IdkNwmPds0mJk/i64btVUa+iz0Z66VPNq82N0Q9vpb73xz1rhfnuY1WJsHYcV6PDgqbyAkET2yg7iouQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bellhop-iframe/-/bellhop-iframe-2.4.2.tgz",
+      "integrity": "sha512-2t7RM8Rc91g34DH+ykS9ieN8RE3ksOdDL715yYpla061k4WGrKJhd8p+pcOpzC7KUKYB2ZXVgmgFy6KzUO9VXQ==",
       "dev": true
     },
     "big.js": {
@@ -6501,11 +6501,12 @@
       }
     },
     "springroll": {
-      "version": "git+https://github.com/SpringRoll/SpringRoll.git#66615fed88293e73115108fdada24610aa0928b6",
-      "from": "git+https://github.com/SpringRoll/SpringRoll.git#v2",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/springroll/-/springroll-2.4.0.tgz",
+      "integrity": "sha512-ADyewtb8aT0PKDHLvpncon6xeofZ6+iKD81fvZR4WvUEh1Wh/IiJCelllChwBvrvyzZ/Gkf3JVrrFBBCajEK6Q==",
       "dev": true,
       "requires": {
-        "bellhop-iframe": "^2.1.1"
+        "bellhop-iframe": "^2.3.1"
       }
     },
     "ssri": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "file-loader": "^2.0.0",
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.2",
-    "springroll": "git+https://github.com/SpringRoll/SpringRoll.git#v2",
+    "springroll": "^2.4.0",
     "webpack": "^4.17.2",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.3.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,10 @@
 import './styles.css';
-import 'springroll';
+import {Application} from 'springroll';
+
+const
+    app = new Application(),
+    state = app.state;
+
+state.pause.subscribe((current) => {
+    // Handle game pause.
+});


### PR DESCRIPTION
This updates package.json so that it loads the latest version of SpringRoll. I think `v2` no longer exists...

I also added `new Application()` to the index so that a host page loading this seed will get the SpringRoll Container "loaded" event. (Plus a stub for pause since it throws a warning otherwise.) 