### PR TITLE
Changed image loading path to relative to resolve loader hang on Windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = env => {
             {
               loader: 'file-loader',
               options: {
-                outputPath: path.join(deploy + 'assets/image')
+                outputPath: './assets/image'
               }
             }
           ]


### PR DESCRIPTION
This change is to resolve this issue: https://github.com/SpringRoll/Springroll-Seed/issues/20

I've tested it on all three active template branches, both in dev and prod build modes. No errors or problems.