### PR TITLE
Feature/184583615 phaser prevent google indexing

### DIFF
--- a/templates/Springroll.html
+++ b/templates/Springroll.html
@@ -9,6 +9,7 @@
     <%= title %>
   </title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="robots" content="noindex">
 </head>
 
 <body>


### PR DESCRIPTION
Added `<meta name="robots" content="noindex">` to prevent Google indexing.

Ticket: https://www.pivotaltracker.com/story/show/184583615