### PR TITLE
Fix asset name of Phaser 3 seed project

### DIFF
--- a/src/scenes/game-scene.js
+++ b/src/scenes/game-scene.js
@@ -6,7 +6,7 @@ export class GameScene extends Scene
     preload()
     {
         // load assets
-        this.load.image('ball', './assets/ball.png')
+        this.load.image('ball', './assets/Ball.png')
         this.load.audio('bounce', ['./assets/bounce.mp3', './assets/bounce.ogg']);
     }
 


### PR DESCRIPTION
The actual filename is 'Ball.png'. So it fails to load the ball image.