### PR TITLE
Replace apple npm registry with npmjs.org registry in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5800,7 +5800,7 @@
     },
     "node_modules/path": {
       "version": "0.12.7",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/path/-/path-0.12.7.tgz",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
       "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
       "dependencies": {
         "process": "^0.11.1",
@@ -6044,7 +6044,7 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "engines": {
         "node": ">= 0.6.0"
@@ -6954,7 +6954,7 @@
     },
     "node_modules/terser-webpack-plugin": {
       "version": "5.3.6",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
       "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "dependencies": {
@@ -7147,7 +7147,7 @@
     },
     "node_modules/util": {
       "version": "0.10.4",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/util/-/util-0.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
       "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
       "dependencies": {
         "inherits": "2.0.3"
@@ -7161,7 +7161,7 @@
     },
     "node_modules/util/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/utila": {
@@ -11949,7 +11949,7 @@
     },
     "path": {
       "version": "0.12.7",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/path/-/path-0.12.7.tgz",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
       "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
       "requires": {
         "process": "^0.11.1",
@@ -12123,7 +12123,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-nextick-args": {
@@ -12814,7 +12814,7 @@
     },
     "terser-webpack-plugin": {
       "version": "5.3.6",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
       "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "requires": {
@@ -12938,7 +12938,7 @@
     },
     "util": {
       "version": "0.10.4",
-      "resolved": "https://artifacts.apple.com/api/npm/npm-private/util/-/util-0.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
       "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
       "requires": {
         "inherits": "2.0.3"
@@ -12946,7 +12946,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://artifacts.apple.com/api/npm/npm-private/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
         }
       }


### PR DESCRIPTION
Fixes #95 

This updates the paths to some modules `package-lock.json` pointing to a (maybe missing) apple.com registry to the public npmjs.org registry.