### PR TITLE
Chore/187228390 - pull 2.0.0 into phaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<<<<<<< HEAD
 ## [1.4.0] - TBD
 
 ### Changed
 
 - Updated Phaser to 3.80.1
 - Fixed warning with SpringRoll listeners
+=======
+## [2.0.0] - 2024-05-09
+
+### Changed
+
+- Pixi: Updated pixi.js to 8.1.0
+- Pixi: Updated @pixi/sound to 6.0.0
+- Pixi: Updated SpringRoll to 2.6.0
+- Pixi: Updated feature list and state listeners to follow a standardized set
+
+- Phaser: Updated Phaser to 3.80.1
+- Phaser: Fixed warning with SpringRoll listeners
+- Phaser: Updated SpringRoll to 2.6.0
+- Phaser: Updated feature list and state listeners to follow a standardized set
+
+>>>>>>> release/2.0.0
 
 ## [1.3.1] - 2023-03-28
 
 ### Fixed
 
+<<<<<<< HEAD
 - Removed incorrect references to non-NPM registry in package lock
+=======
+- Removed incorrect references to non-NPM registry in package-lock
+
+### Changed
+
+- Updated package-lock file to most recent versions
+>>>>>>> release/2.0.0
 
 ## [1.3.0] - 2023-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<<<<<<< HEAD
-## [1.4.0] - TBD
-
-### Changed
-
-- Updated Phaser to 3.80.1
-- Fixed warning with SpringRoll listeners
-=======
 ## [2.0.0] - 2024-05-09
 
 ### Changed
@@ -27,21 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phaser: Updated SpringRoll to 2.6.0
 - Phaser: Updated feature list and state listeners to follow a standardized set
 
->>>>>>> release/2.0.0
 
 ## [1.3.1] - 2023-03-28
 
 ### Fixed
 
-<<<<<<< HEAD
-- Removed incorrect references to non-NPM registry in package lock
-=======
 - Removed incorrect references to non-NPM registry in package-lock
 
 ### Changed
 
 - Updated package-lock file to most recent versions
->>>>>>> release/2.0.0
 
 ## [1.3.0] - 2023-03-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "springroll-seed",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "springroll-seed",
-      "version": "1.3.1",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "phaser": "^3.80.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "springroll-seed",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Pulling the 2.0.0 changelog and version into the Phaser 3 template. This brings the changelog in sync with the main branch.

Ticket: https://www.pivotaltracker.com/story/show/187228390