### PR TITLE
Feature/184506946 drop consoles - Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds
+- added TerserPlugin options to webpack to maintain function names in debug builds
+
 - Pixi: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- Pixi: added TerserPlugin options to webpack to maintain function names in debug builds
+
 - Phaser: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- Phaser: added TerserPlugin options to webpack to maintain function names in debug builds
+
 - CreateJS: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- CreateJS: added TerserPlugin options to webpack to maintain function names in debug builds
 
 ## [2.0.0] - 2024-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - unreleased
+## [2.0.1] - 2024-06-11
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - unreleased
+
+### Changed
+
+- Pixi: added TerserPlugin options to webpack to drop `console.log` in production builds 
+
 ## [2.0.0] - 2024-05-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Pixi: added TerserPlugin options to webpack to drop `console.log` in production builds 
+- added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- Pixi: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- Phaser: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- CreateJS: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
 
 ## [2.0.0] - 2024-05-09
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "source-map-loader": "^1.0.0",
         "springroll": "^2.4.4",
         "style-loader": "^3.3.1",
+        "terser-webpack-plugin": "^5.3.10",
         "webpack": "^5.75.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "springroll-seed",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "springroll-seed",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "springroll-seed",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "eslint-webpack-plugin": "^3.2.0",
     "html-webpack-plugin": "^5.5.0",
     "mini-css-extract-plugin": "^2.6.1",
+    "source-map-loader": "^1.0.0",
+    "springroll": "^2.4.4",
     "style-loader": "^3.3.1",
+    "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.11.1",
-    "source-map-loader": "^1.0.0",
-    "springroll": "^2.4.4"
-  },
-  "dependencies": {}
+    "webpack-dev-server": "^4.11.1"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,2 @@
 import './styles.css';
 import 'springroll';
-
-console.log('hello');
-console.warn('warn');
-console.error('errrror');

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,6 @@
 import './styles.css';
 import 'springroll';
+
+console.log('hello');
+console.warn('warn');
+console.error('errrror');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,10 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
 const deploy = path.join(__dirname, 'deploy');
-const isProduction = process.env.NODE_ENV == "production";
 
-// keep the env param to be explicit, eslint disable should be removed when template is in use
-// eslint-disable-next-line no-unused-vars
 module.exports = (env) => {
+  const isProduction = !!env.production;
+
   const plugins = [
     new CleanPlugin.CleanWebpackPlugin(),
     new HtmlWebpackPlugin(HtmlConfig),
@@ -120,7 +119,7 @@ module.exports = (env) => {
                       keep_fnames: isProduction ? false : true,
                   },
                   compress: {
-                      drop_console: isProduction ? ['log'] : false,
+                      drop_console: isProduction ? ['log', 'info']: false,
                   },
               },
           }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const HtmlConfig = require(path.join(__dirname, 'html.config'));
 const CleanPlugin = require('clean-webpack-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const deploy = path.join(__dirname, 'deploy');
 const isProduction = process.env.NODE_ENV == "production";
@@ -109,6 +110,21 @@ module.exports = (env) => {
           use: ['source-map-loader'],
         },
       ]
-    }
+    },
+    optimization: {
+      minimize: true,
+      minimizer: [
+          new TerserPlugin({
+              terserOptions: {
+                  mangle: {
+                      keep_fnames: isProduction ? false : true,
+                  },
+                  compress: {
+                      drop_console: isProduction ? ['log'] : false,
+                  },
+              },
+          }),
+      ],
+  }
   };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,8 +27,6 @@ module.exports = (env) => {
   return {
     stats: 'errors-only',
 
-    mode: isProduction ? 'production':'development',
-
     devServer: {
       open: true,
       client: { overlay: true },


### PR DESCRIPTION
I've elected to just drop `log` and `info` so we maintain `warn` and `error`. 
I also preserved function names in debug builds just for convenience since I was in there anyway. 

Note: the old `isProduction` check would never return true because the `process.env.NODE_ENV` isn't actually set. The docs are really unclear on this but I tested it out and it doesn't work. But grabbing the `env.production` does work so I've updated the call so it works properly. 