### PR TITLE
Feature/184506946 drop consoles - Phaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - unreleased
+## [2.0.1] - unreleased
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - unreleased
+
+### Changed
+
+- Pixi: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- Pixi: added TerserPlugin options to webpack to maintain function names in debug builds
+
+- Phaser: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- Phaser: added TerserPlugin options to webpack to maintain function names in debug builds
+
+- CreateJS: added TerserPlugin options to webpack to drop `console.log` and `console.info` in production builds 
+- CreateJS: added TerserPlugin options to webpack to maintain function names in debug builds
+
 ## [2.0.0] - 2024-05-09
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "source-map-loader": "^1.0.0",
         "springroll": "^2.4.4",
         "style-loader": "^3.3.1",
-        "terser-webpack-plugin": "^5.3.6",
+        "terser-webpack-plugin": "^5.3.10",
         "webpack": "^5.75.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "springroll-seed",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "springroll-seed",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "phaser": "^3.80.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "springroll-seed",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "source-map-loader": "^1.0.0",
     "springroll": "^2.4.4",
     "style-loader": "^3.3.1",
-    "terser-webpack-plugin": "^5.3.6",
+    "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,12 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
 const deploy = path.join(__dirname, 'deploy');
-const isProduction = process.env.NODE_ENV == "production";
 
 // keep the env param to be explicit, eslint disable should be removed when template is in use
 // eslint-disable-next-line no-unused-vars
 module.exports = (env) => {
+  const isProduction = !!env.production;
+
   const plugins = [
     new CleanPlugin.CleanWebpackPlugin(),
     new HtmlWebpackPlugin(HtmlConfig),
@@ -47,10 +48,21 @@ module.exports = (env) => {
     },
 
     optimization: {
-      minimizer: [new TerserPlugin({
-        extractComments: true
-      })]
-    },
+      minimize: true,
+      minimizer: [
+          new TerserPlugin({
+            
+              terserOptions: {
+                  mangle: {
+                      keep_fnames: isProduction ? false : true,
+                  },
+                  compress: {
+                      drop_console: isProduction ? ['log', 'info']: false,
+                  },
+              },
+          }),
+      ],
+  },
 
     plugins,
 


### PR DESCRIPTION
Same as #120 

Added Note: The Phaser webpack config had `extractComments` as a Terser option already. I believe it was added during the webpack v5 update to match an old uglify option. But Terser just removes most comments by default and that option extracted it to another file so I just removed it to keep this template in line with the others